### PR TITLE
add sail support to ide helper commands

### DIFF
--- a/lua/laravel/ide_helper.lua
+++ b/lua/laravel/ide_helper.lua
@@ -3,6 +3,7 @@
 local M = {}
 
 local ui = require('laravel.ui')
+local sail = require('laravel.sail')
 
 -- Cache for IDE helper completions
 local cache = {
@@ -78,9 +79,9 @@ local function ensure_ide_helper_files()
         if choice == 1 then
             -- Generate files
             local commands = {
-                'php artisan ide-helper:generate',
-                'php artisan ide-helper:models --write',
-                'php artisan ide-helper:meta'
+                sail.wrap_command('php artisan ide-helper:generate'),
+                sail.wrap_command('php artisan ide-helper:models --write'),
+                sail.wrap_command('php artisan ide-helper:meta')
             }
 
             for _, cmd in ipairs(commands) do

--- a/plugin/laravel.lua
+++ b/plugin/laravel.lua
@@ -6,6 +6,8 @@ if vim.g.loaded_laravel_nvim then
 end
 vim.g.loaded_laravel_nvim = true
 
+local sail = require('laravel.sail')
+
 -- Check if we're in a Laravel project
 local function is_laravel_project()
     local markers = { 'artisan', 'composer.json', 'app/Http', 'config/app.php' }
@@ -589,13 +591,13 @@ local function setup_commands()
         local root = _G.laravel_nvim.project_root
 
         local commands = {
-            generate = 'php artisan ide-helper:generate',
-            models = 'php artisan ide-helper:models --write',
-            meta = 'php artisan ide-helper:meta',
+            generate = sail.wrap_command('php artisan ide-helper:generate'),
+            models = sail.wrap_command('php artisan ide-helper:models --write'),
+            meta = sail.wrap_command('php artisan ide-helper:meta'),
             all = {
-                'php artisan ide-helper:generate',
-                'php artisan ide-helper:models --write',
-                'php artisan ide-helper:meta'
+                sail.wrap_command('php artisan ide-helper:generate'),
+                sail.wrap_command('php artisan ide-helper:models --write'),
+                sail.wrap_command('php artisan ide-helper:meta')
             }
         }
 


### PR DESCRIPTION
## Problem
IDE Helper commands (generate, models, meta) were not working in a Sail based environment.

## Solution
Wrap IDE Helper commands with Sail, similarly to how it's done in commit [#7336943](73369437ab3e67718f98021fee3ec064b29897f5), file [lua/laravel/artisan.lua](https://github.com/adibhanna/laravel.nvim/blob/7e229936a541beca5441fc3285d761740524c272/lua/laravel/artisan.lua)